### PR TITLE
Temporary fix for uc@3.1.x and py310

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -9,7 +9,7 @@ import time
 from io import BytesIO
 
 import PIL.Image as pil_image
-import undetected_chromedriver as uc
+import undetected_chromedriver._compat as uc
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.keys import Keys


### PR DESCRIPTION
undetected_chromedriver两个月前发布了3.1.0，downloader不能在此版本下正常工作；
如果pip指定安装3.0.4，又可能会因为用户使用的是Py3.10，而Python 3.10废弃了collections.Mapping等使得uc不能正常工作。
目前简单的解法就是使用`uc._compat`，即uc#3.1.x以前的uc v1。
当然，更好的解法是使用v2的api。