### PR TITLE
Fixed downloads for Selenium version 4.3.0

### DIFF
--- a/website_actions/bookwalker_jp_actions.py
+++ b/website_actions/bookwalker_jp_actions.py
@@ -4,6 +4,7 @@ Website actions for bookwalker.jp
 import base64
 
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 try:
     from abstract_website_actions import WebsiteActions
@@ -33,7 +34,7 @@ class BookwalkerJP(WebsiteActions):
         return manga_url.find('bookwalker.jp') != -1
 
     def get_sum_page_count(self, driver):
-        return int(str(driver.find_element_by_id('pageSliderCounter').text).split('/')[1])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[1])
 
     def move_to_page(self, driver, page):
         driver.execute_script(
@@ -41,13 +42,13 @@ class BookwalkerJP(WebsiteActions):
 
     def wait_loading(self, driver):
         WebDriverWait(driver, 600).until_not(lambda x: self.check_is_loading(
-            x.find_elements_by_css_selector(".loading")))
+            x.find_elements(By.CSS_SELECTOR, ".loading")))
 
     def get_imgdata(self, driver, now_page):
-        canvas = driver.find_element_by_css_selector(".currentScreen canvas")
+        canvas = driver.find_element(By.CSS_SELECTOR, ".currentScreen canvas")
         img_base64 = driver.execute_script(
             "return arguments[0].toDataURL('image/png', 1.0).substring(21);", canvas)
         return base64.b64decode(img_base64)
 
     def get_now_page(self, driver):
-        return int(str(driver.find_element_by_id('pageSliderCounter').text).split('/')[0])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[0])

--- a/website_actions/bookwalker_tw_actions.py
+++ b/website_actions/bookwalker_tw_actions.py
@@ -4,6 +4,7 @@ Website actions for bookwalker.com.tw
 import base64
 
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 try:
     from abstract_website_actions import WebsiteActions
@@ -33,7 +34,7 @@ class BookwalkerTW(WebsiteActions):
         return manga_url.find('bookwalker.com.tw') != -1
 
     def get_sum_page_count(self, driver):
-        return int(str(driver.find_element_by_id('pageSliderCounter').text).split('/')[1])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[1])
 
     def move_to_page(self, driver, page):
         driver.execute_script(
@@ -41,13 +42,13 @@ class BookwalkerTW(WebsiteActions):
 
     def wait_loading(self, driver):
         WebDriverWait(driver, 600).until_not(lambda x: self.check_is_loading(
-            x.find_elements_by_css_selector(".loading")))
+            x.find_elements(By.CSS_SELECTOR, ".loading")))
 
     def get_imgdata(self, driver, now_page):
-        canvas = driver.find_element_by_css_selector(".currentScreen canvas")
+        canvas = driver.find_element(By.CSS_SELECTOR, ".currentScreen canvas")
         img_base64 = driver.execute_script(
             "return arguments[0].toDataURL('image/png', 1.0).substring(21);", canvas)
         return base64.b64decode(img_base64)
 
     def get_now_page(self, driver):
-        return int(str(driver.find_element_by_id('pageSliderCounter').text).split('/')[0])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[0])

--- a/website_actions/cmoa_jp_actions.py
+++ b/website_actions/cmoa_jp_actions.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 import PIL.Image as pil_image
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 try:
     from abstract_website_actions import WebsiteActions
@@ -49,11 +50,10 @@ class CmoaJP(WebsiteActions):
 
     def wait_loading(self, driver):
         WebDriverWait(driver, 600).until_not(
-            lambda x: x.find_element_by_id("start_wait"))
+            lambda x: x.find_element(By.ID, "start_wait"))
 
     def get_imgdata(self, driver, now_page):
-        image_elements = driver.find_element_by_id(
-            'content-p%d' % now_page).find_elements_by_css_selector('img')
+        image_elements = driver.find_element(By.ID, 'content-p%d' % now_page).find_elements(By.CSS_SELECTOR, 'img')
 
         imgs_arr = []
         imgs_height = [0]

--- a/website_actions/coma_jp_novel.py
+++ b/website_actions/coma_jp_novel.py
@@ -5,6 +5,7 @@ import base64
 import time
 
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 try:
     from abstract_website_actions import WebsiteActions
@@ -60,7 +61,7 @@ class CmoaJPNovels(WebsiteActions):
 
     def wait_loading(self, driver):
         WebDriverWait(driver, 600).until_not(
-            lambda x: x.find_element_by_id('ctmble_menu_notification_overlay_span').is_displayed())
+            lambda x: x.find_element(By.ID, 'ctmble_menu_notification_overlay_span').is_displayed())
 
     def get_imgdata(self, driver, now_page):
         return driver.get_screenshot_as_png()
@@ -70,7 +71,7 @@ class CmoaJPNovels(WebsiteActions):
 
     def before_download(self, driver):
         WebDriverWait(driver, 600).until_not(
-            lambda x: x.find_element_by_id('preMessage'))
-        driver.switch_to.frame(driver.find_element_by_id('binb'))
+            lambda x: x.find_element(By.ID, 'preMessage'))
+        driver.switch_to.frame(driver.find_element(By.ID, 'binb'))
         WebDriverWait(driver, 600).until_not(
-            lambda x: x.find_element_by_id('msg_outer_div').is_displayed())
+            lambda x: x.find_element(By.ID, 'msg_outer_div').is_displayed())

--- a/website_actions/takeshobo_co_jp_actions.py
+++ b/website_actions/takeshobo_co_jp_actions.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 import PIL.Image as pil_image
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 try:
     from abstract_website_actions import WebsiteActions
@@ -49,11 +50,10 @@ class CmoaJP(WebsiteActions):
 
     def wait_loading(self, driver):
         WebDriverWait(driver, 600).until_not(
-            lambda x: x.find_element_by_id("start_wait"))
+            lambda x: x.find_element(By.ID, "start_wait"))
 
     def get_imgdata(self, driver, now_page):
-        image_elements = driver.find_element_by_id(
-            'content-p%d' % now_page).find_elements_by_css_selector('img')
+        image_elements = driver.find_element(By.ID, 'content-p%d' % now_page).find_elements(By.CSS_SELECTOR, 'img')
 
         imgs_arr = []
         imgs_height = [0]


### PR DESCRIPTION
Selenium 4.3.0 [Changelog](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES) shows:
```
Selenium 4.3.0
* Deprecated find_element_by_* and find_elements_by_* are now removed (#10712)
* Deprecated Opera support has been removed (#10630)
* Fully upgraded from python 2x to 3.7 syntax and features (#10647)
* Added a devtools version fallback mechanism to look for an older version when mismatch occurs (#10749)
* Better support for co-operative multi inheritance by utilising super() throughout
* Improved type hints throughout
```

So, I've made the necessary changes for it to work from that version.