### PR TITLE
add cut_image = dynamic

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,8 @@ settings = {
     'loading_wait_time': 20,
     # Cut image, (left, upper, right, lower) in pixel, None means do not cut the image. This often used to cut the edge.
     # Like (0, 0, 0, 3) means cut 3 pixel from bottom of the image.
+    # or set dynamic to allow the scrypt to cut_images dynamictly (This work only correct if start_page is None)
+    # this removed whitespace on the corners, initialised by the Cover.
     'cut_image': None,
     # File name prefix, if you want your file name like 'klk_v1_001.jpg', write 'klk_v1' here.
     'file_name_prefix': '',


### PR DESCRIPTION
The change I made ensures that instead of entering a fixed value for cut_image, you can say that the image should be dynamically cropped. For this it takes the first image (should be the cover) and looks at where a white border exists and returns this as a bbox so that the crop method knows where to remove the white border and takes over the values for the rest of the band. This way, if you dump several series, the programme can easily ensure that you no longer have a white border in any manga. 

to get the above you only have to set cut_image = 'dynamic'.