### PR TITLE
Fix `BookwalkerTW` cannot get `pageSliderCounter` content

### DIFF
--- a/website_actions/bookwalker_tw_actions.py
+++ b/website_actions/bookwalker_tw_actions.py
@@ -35,7 +35,7 @@ class BookwalkerTW(WebsiteActions):
         return manga_url.find('bookwalker.com.tw') != -1
 
     def get_sum_page_count(self, driver):
-        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[1])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').get_attribute('textContent')).split('/')[1])
 
     def move_to_page(self, driver, page):
         driver.execute_script(
@@ -52,7 +52,7 @@ class BookwalkerTW(WebsiteActions):
         return base64.b64decode(img_base64)
 
     def get_now_page(self, driver):
-        return int(str(driver.find_element(By.ID, 'pageSliderCounter').text).split('/')[0])
+        return int(str(driver.find_element(By.ID, 'pageSliderCounter').get_attribute('textContent')).split('/')[0])
     
     def before_download(self, driver):
         for key in driver.execute_script('return Object.keys(NFBR.a6G.Initializer)'):


### PR DESCRIPTION
Update the method for obtaining the value of `pageSliderCounter` in `BookwalkerTW` to sync with the method used in [`BookwalkerJP`](https://github.com/xuzhengyi1995/Manga_downloader/blob/1c7a7fcd602f548a48e30487d9a9e359a363e6ea/website_actions/bookwalker_jp_actions.py#L38)